### PR TITLE
docs: add link to `version.md` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ We have agreed to these practices by consensus. They document heuristics, as det
 
 * [Git](git.md)
 * [Repository Maintainer Guidelines](maintainer.md)
+* [Versioning](version.md)
 
 We also keep public documentation of interesting resources (best practices and otherwise) here:
 


### PR DESCRIPTION
Looks like I forgot to do this in #34 