### PR TITLE
docs: Update refs of `RMI-PACTA` to `RMI`

### DIFF
--- a/git.md
+++ b/git.md
@@ -47,7 +47,7 @@ Like an email, commit messages have a subject and an optional body. The subject 
 
 See also:
 
--   [Example of a commit message](https://github.com/RMI-PACTA/resources/issues/74)
+-   [Example of a commit message](https://github.com/RMI/resources/issues/74)
 -   [Commit best practices](https://r-pkgs.org/git.html#commit-best-practices)
 
 ## Agree on a workflow

--- a/maintainer.md
+++ b/maintainer.md
@@ -2,7 +2,7 @@
 
 A network of active maintainers can help lead to a well-functioning software ecosystem. Maintainers are responsible for the health of a repository, which includes its functionality, documentation, and communication. Maintainers are also responsible for the health of the community around the repository, which includes the responsiveness of the maintainers, the clarity of the repository’s purpose, and the accessibility of the repository to new users.
 
-Below is the the RMI-PACTA Tech Team's guidance for what it means to be the maintainer of a repository. The guidance is not necessarily exhaustive, but should give an idea of what the expectations are of a maintainer.
+Below is the the RMI Software Product and Data Team's guidance for what it means to be the maintainer of a repository. The guidance is not necessarily exhaustive, but should give an idea of what the expectations are of a maintainer.
 
 ## Communication
 

--- a/version.md
+++ b/version.md
@@ -23,7 +23,7 @@ This means, either standard SemVer, or the CalVer variant as described above. Th
 
 ## Other Repositories
 
-At this stage, no clear guidance is given for other `RMI-PACTA` repositories. In general, some consistent tagging system may be useful (e.g. tag relevant images with `date-built`, or `COP CH 2024`, or other useful user-facing tags), but the specifics of this are left to the discretion of the repository maintainers.
+At this stage, no clear guidance is given for other `RMI` repositories. In general, some consistent tagging system may be useful (e.g. tag relevant images with `date-built`, or `COP CH 2024`, or other useful user-facing tags), but the specifics of this are left to the discretion of the repository maintainers.
 
 ## References
 


### PR DESCRIPTION
We have moved the practices repo to the broader "RMI" organization, and links must be updated accordingly. 

Given that this change doesn't affect the spirit of any of the stated practices, I will be bypassing the "approve by consensus" rules, and merge this after 1 approving review. 