### PR TITLE
Include PRD Template to practices repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ We have agreed to these practices by consensus. They document heuristics, as det
 * [Pull Requests](pull_request.md)
 * [Repository Maintainer Guidelines](maintainer.md)
 * [Versioning](version.md)
+* [PRD Template](prd_template.md)
 
 We also keep public documentation of interesting resources (best practices and otherwise) here:
 

--- a/prd_template.md
+++ b/prd_template.md
@@ -14,7 +14,7 @@ team is involved in. For a Word Doc version of this template, follow [this link]
 |-----------------------|--------------------------------|
 | Assigned SPD PM:      |                                |
 | Document Created:     |                                |
-| Document Las Updated: |                                |
+| Document Last Updated: |                                |
 | Document Status:      | \[Draft, In Review, Approved\] |
 
 ## Problem Description

--- a/prd_template.md
+++ b/prd_template.md
@@ -1,0 +1,77 @@
+# Product Requirements Document Template
+
+This template should be used whenever there is a need to define the scope and requirements of a project that the SPD 
+team is involved in. For a Word Doc version of this template, follow [this link](https://rockmtnins.sharepoint.com/:w:/s/ClimateIntelligence/EVPvEob5rZhFkfzNeiSSQewBt-yBTSrQgOuHb0OfsdA2Ng?e=dRhAKl).
+
+# SPD Product Requirement Document: \<insert project title\> 
+
+*Instructions:*<br>
+* *Make a copy of this template*
+* *Move it into SPD’s [Proposals](https://rockmtnins.sharepoint.com/:f:/s/ClimateIntelligence/Eq4_rt347aRPpzbh2wUVRQMBZyqfTGdhyoXsLb3SuGeLFg?e=fQ0rEg) folder within [CIP’s Sharepoint](https://rockmtnins.sharepoint.com/sites/ClimateIntelligence/SitePages/CIP%20Program%20Overview.aspx)* 
+* *Fill out every section to the best of your ability (feel free to delete everything in italics, including these instructions)*
+
+|                       |                                |
+|-----------------------|--------------------------------|
+| Assigned SPD PM:      |                                |
+| Document Created:     |                                |
+| Document Las Updated: |                                |
+| Document Status:      | \[Draft, In Review, Approved\] |
+
+## Problem Description
+
+*Describe what problem/capability gap that the proposing team currently has. This should be just a few sentences describing what is “missing” from the team’s perspective and why that is a problem. Please do not focus on any potential solutions here.* 
+
+## Background/Current State
+
+*Please describe and/or link to any current documentation, code, current work, etc. that would give the SPD team the context needed to better understand the problem description and the relevant domain knowledge needed to understand the problem*
+
+## Goals & Non-Goals
+
+*What are the two or three goals you’re aiming to achieve? And what are things that would be great to have but are not a focus (yet)? E.g., goal: allow governments to understand emissions at company level and non-goal: create a revenue generating consumer-app showing emissions*
+
+## Impact
+
+*If this project is successful, what will change in the real world? Who or what will change because of it? If you have a theory of change already, this should be straightforward.*
+
+## User Descriptions
+
+*Who is currently running into this problem and who are we trying to help? Is this an issue that internal RMI-ers are encountering or is this a problem for external folks or both? How would you describe each potential type of user affected by this problem in one sentence?*<br>
+* *User Persona 1: \<describe\>* 
+* *User Persona 2: \<describe\>* 
+* *Etc.*
+
+## High Level Design Overview
+
+*Provide a short description for each major component that is needed to address the problem we are focused on.*
+
+## Milestones & Logistics
+
+*What could be considered the MVP for this product? How could we break up the total product into achievable and realistic milestones? What budget/timeline/funder/etc. constraints do you have when it comes to addressing this problem?*
+
+## User Journey Example
+*How would one of the User Persona’s day to day activities be different if they now had access to our solution compared to their previous problem state? Can we walk through how the solution would assist them?*
+
+## Detailed Requirements
+
+*What actions or behaviors must be possible for our user(s) so that they no longer experience the problem? To be clear, this is still not focusing on a specific solution but rather focuses on what must be possible for a solution to be considered viable. These should also be prioritized, if possible, using the scale P0, P1, P2.* 
+
+*These requirements can also be further refined into sections. Either sections that help structure the overall product design (e.g. “Frontend requirements, backend requirements, etc.), or sections that delineate “Functional Requirements” (specific features or functions of the product) from “Non-Functional Requirements” (describe how the system performs and addresses qualities or constraints of the system).*
+
+*P0 – This capability must be possible or else a solution would be considered incomplete and unacceptable.*
+
+*P1 – This capability is highly desirable and would be noticeable if it wasn’t available; but if need be, it could be excluded from the solution.*
+
+*P2 – This is a “nice to have”; this capability would be well received by users but it would not be sorely missed if it was not available.*
+
+## Metrics
+
+*What metrics do we think are important to track? What data do we need to understand if we were successful?*
+
+## Potential Roadmap & Future Work 
+
+*What would a roadmap of future improvements look like for this product if there was additional funding? Are there any additional capabilities that we might want to investigate and explore?*
+
+## Post-deliverable maintenance & Sunsetting 
+
+*What is the maintenance plan for this project once primary work is completed? Is SPD expected to own any solution and just provide access to the tool? Is SPD expected to provide ongoing support if there are any bugs/future issues? What is the plan to sunset this project?*
+

--- a/prd_template.md
+++ b/prd_template.md
@@ -19,15 +19,16 @@ team is involved in. For a Word Doc version of this template, follow [this link]
 
 ## Problem Description
 
-*Describe what problem/capability gap that the proposing team currently has. This should be just a few sentences describing what is “missing” from the team’s perspective and why that is a problem. Please do not focus on any potential solutions here.* 
+*Describe the problem/capability gap that has been identified. This should be no more than a paragraph or two describing the current state of affairs and why it is a problem for a group of users. Please do not focus on any potential solutions here.* 
 
 ## Background/Current State
 
-*Please describe and/or link to any current documentation, code, current work, etc. that would give the SPD team the context needed to better understand the problem description and the relevant domain knowledge needed to understand the problem*
+*Please describe and/or link to any current documentation, code, current work, etc. that would give the reader of this document the context needed to better understand the problem description and the relevant domain knowledge needed to understand the problem*
 
 ## Goals & Non-Goals
 
-*What are the two or three goals you’re aiming to achieve? And what are things that would be great to have but are not a focus (yet)? E.g., goal: allow governments to understand emissions at company level and non-goal: create a revenue generating consumer-app showing emissions*
+*What are the two or three goals we want to achieve with this product work? And what are things that would be great to have but are not a focus (yet)?*<br> 
+*E.g. goal: allow governments to understand emissions at company level and non-goal: create a revenue generating consumer-app showing emissions*
 
 ## Impact
 
@@ -71,7 +72,7 @@ team is involved in. For a Word Doc version of this template, follow [this link]
 
 *What would a roadmap of future improvements look like for this product if there was additional funding? Are there any additional capabilities that we might want to investigate and explore?*
 
-## Post-deliverable maintenance & Sunsetting 
+## Post-Deliverable Maintenance & Sunsetting 
 
 *What is the maintenance plan for this project once primary work is completed? Is SPD expected to own any solution and just provide access to the tool? Is SPD expected to provide ongoing support if there are any bugs/future issues? What is the plan to sunset this project?*
 

--- a/prd_template.md
+++ b/prd_template.md
@@ -27,8 +27,10 @@ team is involved in. For a Word Doc version of this template, follow [this link]
 
 ## Goals & Non-Goals
 
-*What are the two or three goals we want to achieve with this product work? And what are things that would be great to have but are not a focus (yet)?*<br> 
-*E.g. goal: allow governments to understand emissions at company level and non-goal: create a revenue generating consumer-app showing emissions*
+* *What are the two or three goals we want to achieve with this product work?*
+  * *e.g. **goal:** Allow governments to understand emissions at company level* 
+* *What are things that would be great to have but are not a focus (yet)?*
+  * *e.g. **non-goal:** Create a revenue generating consumer-app showing emissions*
 
 ## Impact
 


### PR DESCRIPTION
Adding a page that gives a template to follow when creating a PRD. The template includes sections that are all helpful to have when creating a PRD but this template should not be thought of as purely prescriptive. Each other can adjust as needed depending on what will work best for the product they are working on.